### PR TITLE
Replace external chart and icon dependencies with local implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/NextMind/public/favicon.ico" />
+    <link rel="icon" type="image/png" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NextMind</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
-        "typescript": "^5.9.2",
+        "typescript": "5.8.2",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5"
       }
@@ -3837,9 +3837,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "typescript": "^5.9.2",
+    "typescript": "5.8.2",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"
   }

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -8,11 +8,16 @@
   border-right: 1px solid rgba(255,255,255,0.03);
 }
 
-.sidebar-brand h2 {
-  color: #47b36a;
+.sidebar-brand {
   text-align: center;
-  margin: 0 0 0.6rem 0;
-  width: 10px;  
+}
+
+.sidebar-brand img {
+  max-width: 150px;
+  width: 100%;
+  height: auto;
+  display: inline-block;
+  filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.3));
 }
 
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,6 @@
+import { type ReactNode } from "react";
 import "./Sidebar.css";
-import {
-  FiCalendar,
-  FiMapPin,
-  FiMessageSquare,
-  FiSettings,
-  FiLogOut,
-} from "react-icons/fi";
+import logo from "../assets/NextMindLogo.png";
 
 interface SidebarProps {
   ativo: string;
@@ -14,7 +9,7 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ ativo, setAtivo, onLogout }: SidebarProps) {
-  const Item = ({ id, icon, label }: { id: string; icon: any; label: string }) => (
+  const Item = ({ id, icon, label }: { id: string; icon: ReactNode; label: string }) => (
     <li
       className={ativo === id ? "ativo sidebar-item" : "sidebar-item"}
       onClick={() => setAtivo(id)}
@@ -30,21 +25,21 @@ export default function Sidebar({ ativo, setAtivo, onLogout }: SidebarProps) {
   return (
     <aside className="sidebar">
       <div className="sidebar-brand">
-        <h2><img src="\src\assets\NextMindLogo.png" alt="NextMind" width={150} /></h2>
+        <img src={logo} alt="NextMind" width={150} />
       </div>
 
       <nav>
         <ul>
-          <Item id="dashboard" icon={<FiCalendar />} label="Dashboard" />
-          <Item id="consultas" icon={<FiMapPin />} label="Consultas" />
-          <Item id="chat" icon={<FiMessageSquare />} label="Chat" />
-          <Item id="configuracoes" icon={<FiSettings />} label="Configurações" />
+          <Item id="dashboard" icon={<span aria-hidden="true">📊</span>} label="Dashboard" />
+          <Item id="consultas" icon={<span aria-hidden="true">📅</span>} label="Consultas" />
+          <Item id="chat" icon={<span aria-hidden="true">💬</span>} label="Chat" />
+          <Item id="configuracoes" icon={<span aria-hidden="true">⚙️</span>} label="Configurações" />
         </ul>
       </nav>
 
       {onLogout && (
         <button className="logout-btn" onClick={onLogout} aria-label="Logout">
-          <FiLogOut />
+          <span aria-hidden="true">🚪</span>
           <span>Logout</span>
         </button>
       )}

--- a/src/components/SimpleLineChart.css
+++ b/src/components/SimpleLineChart.css
@@ -1,0 +1,32 @@
+.simple-line-chart {
+  background: linear-gradient(135deg, #1f2937, #374151);
+  border-radius: 16px;
+  padding: 24px;
+  color: #f9fafb;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.25);
+}
+
+.simple-line-chart svg {
+  display: block;
+}
+
+.simple-line-chart__legend {
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  font-size: 0.875rem;
+}
+
+.simple-line-chart__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.simple-line-chart__legend-item .legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  display: inline-block;
+}

--- a/src/components/SimpleLineChart.tsx
+++ b/src/components/SimpleLineChart.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useId } from "react";
+import "./SimpleLineChart.css";
+
+interface LineSeries {
+  data: number[];
+  label: string;
+  color: string;
+}
+
+interface SimpleLineChartProps {
+  xLabels: (string | number)[];
+  series: LineSeries[];
+  width?: number;
+  height?: number;
+  title?: string;
+}
+
+const DEFAULT_WIDTH = 800;
+const DEFAULT_HEIGHT = 320;
+const PADDING = 48;
+
+export default function SimpleLineChart({
+  xLabels,
+  series,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  title = "Gráfico de linhas",
+}: SimpleLineChartProps) {
+  const chart = useMemo(() => {
+    if (!series.length || !xLabels.length) {
+      return null;
+    }
+
+    const totalPoints = xLabels.length;
+    const values = series.flatMap((item) => item.data.slice(0, totalPoints));
+    const minValue = Math.min(...values);
+    const maxValue = Math.max(...values);
+    const range = maxValue - minValue || 1;
+    const innerWidth = width - PADDING * 2;
+    const innerHeight = height - PADDING * 2;
+
+    const projectX = (index: number) =>
+      totalPoints === 1
+        ? width / 2
+        : PADDING + (index / (totalPoints - 1)) * innerWidth;
+
+    const projectY = (value: number) =>
+      height - PADDING - ((value - minValue) / range) * innerHeight;
+
+    const polylines = series.map((serie) => ({
+      label: serie.label,
+      color: serie.color,
+      points: serie.data.slice(0, totalPoints).map((value, index) => ({
+        x: projectX(index),
+        y: projectY(value),
+        value,
+      })),
+    }));
+
+    const stepApprox = range / 4;
+    const step = stepApprox <= 1 ? 1 : Math.ceil(stepApprox / 5) * 5;
+    const ticks: number[] = [];
+    const start = Math.floor(minValue / step) * step;
+    for (let value = start; value <= maxValue; value += step) {
+      ticks.push(value);
+    }
+    if (!ticks.includes(maxValue)) {
+      ticks.push(maxValue);
+    }
+
+    return { polylines, projectX, minValue, maxValue, range, ticks };
+  }, [height, series, width, xLabels]);
+
+  const titleId = useId();
+  const titleElementId = `${titleId}-title`;
+
+  return (
+    <figure className="simple-line-chart">
+      <svg
+        role="img"
+        aria-labelledby={titleElementId}
+        viewBox={`0 0 ${width} ${height}`}
+        width="100%"
+        height={height}
+      >
+        <title id={titleElementId}>{title}</title>
+        <desc>{series.map((serie) => `${serie.label}: ${serie.data.join(", ")}`).join(" | ")}</desc>
+
+        {/* Eixo X */}
+        <line
+          x1={PADDING}
+          x2={width - PADDING / 2}
+          y1={height - PADDING}
+          y2={height - PADDING}
+          stroke="#d1d5db"
+          strokeWidth={1}
+        />
+
+        {/* Labels do eixo X */}
+        {xLabels.map((label, index) => (
+          <text
+            key={`${label}-${index}`}
+            x={chart ? chart.projectX(index) : width / 2}
+            y={height - PADDING + 20}
+            fontSize={14}
+            textAnchor="middle"
+            fill="#6b7280"
+          >
+            {label}
+          </text>
+        ))}
+
+        {/* Grid horizontal e labels do eixo Y */}
+        {chart?.ticks.map((tick) => {
+          const ratio = chart.range ? (tick - chart.minValue) / chart.range : 0;
+          const y = height - PADDING - ratio * (height - PADDING * 2);
+          return (
+            <g key={`tick-${tick}`}>
+              <line x1={PADDING} x2={width - PADDING / 2} y1={y} y2={y} stroke="#f3f4f6" strokeWidth={1} />
+              <text x={PADDING - 12} y={y + 4} textAnchor="end" fontSize={12} fill="#6b7280">
+                {tick}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Séries */}
+        {chart?.polylines.map((serie) => (
+          <g key={serie.label}>
+            <polyline
+              points={serie.points.map((point) => `${point.x},${point.y}`).join(" ")}
+              fill="none"
+              stroke={serie.color}
+              strokeWidth={2}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+            {serie.points.map((point, index) => (
+              <g key={`${serie.label}-point-${index}`}> 
+                <circle cx={point.x} cy={point.y} r={4} fill={serie.color} />
+              </g>
+            ))}
+          </g>
+        ))}
+      </svg>
+
+      {chart && (
+        <figcaption className="simple-line-chart__legend">
+          {chart.polylines.map((serie) => (
+            <span key={serie.label} className="simple-line-chart__legend-item">
+              <span className="legend-dot" aria-hidden style={{ backgroundColor: serie.color }} />
+              {serie.label}
+            </span>
+          ))}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/src/pages/Consultas/Consultas.tsx
+++ b/src/pages/Consultas/Consultas.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import "./Consultas.css";
 import Card from "../../components/Card";
-import { FiCalendar, FiMapPin } from "react-icons/fi";
 
 interface Consulta {
   paciente: string;
@@ -39,13 +38,13 @@ export default function Consultas() {
         <Card
           titulo="Consultas desta semana"
           descricao={`Você tem ${consultas.length} consultas`}
-          icon={<FiCalendar />}
+          icon={<span aria-hidden="true">📅</span>}
           destaque={String(consultas.length)}
         />
         <Card
           titulo="Eventos do mês"
           descricao={`${eventos.length} eventos`}
-          icon={<FiMapPin />}
+          icon={<span aria-hidden="true">📍</span>}
           destaque={String(eventos.length)}
         />
       </section>

--- a/src/pages/Dasboard/Dashboard.tsx
+++ b/src/pages/Dasboard/Dashboard.tsx
@@ -1,14 +1,8 @@
 import { useState } from "react";
 import Sidebar from "../../components/Sidebar";
 import Card from "../../components/Card";
+import SimpleLineChart from "../../components/SimpleLineChart";
 import "./Dashboard.css";
-import {
-  FiCalendar,
-  FiMapPin,
-  FiMessageSquare,
-  FiBell,
-} from "react-icons/fi";
-import { LineChart } from '@mui/x-charts/LineChart';
 import Consultas from "../Consultas/Consultas";
 import Chat from "../Chat/Chat";
 import Configuracoes from "../Configuracoes/Configuracoes";
@@ -25,59 +19,56 @@ export default function Dashboard({ onLogout }: DashboardProps) {
     <div className="dashboard-container">
       <Sidebar ativo={ativo} setAtivo={setAtivo} onLogout={onLogout} />
 
-     <main className="conteudo-principal">
-  {ativo === "dashboard" && (
-    <section className="cards-row" aria-label="Resumo">
-      <Card
-        titulo="Consultas desta semana"
-        descricao="Você tem 5 consultas agendadas esta semana."
-        icon={<FiCalendar />}
-        destaque="5"
-      />
-      <Card
-        titulo="Eventos do mês"
-        descricao="3 eventos programados"
-        icon={<FiMapPin />}
-        destaque="3"
-      />
-      <Card
-        titulo="Mensagens"
-        descricao="Você tem 5 conversas não lidas"
-        icon={<FiMessageSquare />}
-        destaque="5"
-      />
-      <Card
-        titulo="Notificações"
-        descricao="5 notificações novas"
-        icon={<FiBell />}
-        destaque="5"
-      />
-    </section>
-  )}
+      <main className="conteudo-principal">
+        {ativo === "dashboard" && (
+          <section className="cards-row" aria-label="Resumo">
+            <Card
+              titulo="Consultas desta semana"
+              descricao="Você tem 5 consultas agendadas esta semana."
+              icon={<span aria-hidden="true">📅</span>}
+              destaque="5"
+            />
+            <Card
+              titulo="Eventos do mês"
+              descricao="3 eventos programados"
+              icon={<span aria-hidden="true">📍</span>}
+              destaque="3"
+            />
+            <Card
+              titulo="Mensagens"
+              descricao="Você tem 5 conversas não lidas"
+              icon={<span aria-hidden="true">💬</span>}
+              destaque="5"
+            />
+            <Card
+              titulo="Notificações"
+              descricao="5 notificações novas"
+              icon={<span aria-hidden="true">🔔</span>}
+              destaque="5"
+            />
+          </section>
+        )}
 
- <section className={`painel ${ativo}`}>
-    {ativo === "dashboard" && (
-      <>
-        <h3>Evolução Acadêmica dos Alunos</h3>
-        <LineChart
-          xAxis={[{ data: [1, 2, 3, 4, 5, 6, 7], label: "Semanas" }]}
-          series={[
-            { data: [65, 72, 78, 80, 85, 90, 93], label: "Média da turma (%)", color: "#ffffff" },
-            { data: [60, 68, 75, 77, 83, 87, 92], label: "Paciente João (%)", color: "#ffffff" },
-          ]}
-          width={1500}
-          height={320}
-          sx={{ backgroundColor: "grey", borderRadius: 2 }}
-        />
-      </>
-    )}
+        <section className={`painel ${ativo}`}>
+          {ativo === "dashboard" && (
+            <>
+              <h3>Evolução Acadêmica dos Alunos</h3>
+              <SimpleLineChart
+                title="Evolução Acadêmica dos Alunos"
+                xLabels={["Sem 1", "Sem 2", "Sem 3", "Sem 4", "Sem 5", "Sem 6", "Sem 7"]}
+                series={[
+                  { data: [65, 72, 78, 80, 85, 90, 93], label: "Média da turma (%)", color: "#60a5fa" },
+                  { data: [60, 68, 75, 77, 83, 87, 92], label: "Paciente João (%)", color: "#a78bfa" },
+                ]}
+              />
+            </>
+          )}
 
-    {ativo === "consultas" && <Consultas />}
-    {ativo === "chat" &&  <Chat />}
-    {ativo === "configuracoes" && <Configuracoes/>}
-  </section>
-</main>
-
+          {ativo === "consultas" && <Consultas />}
+          {ativo === "chat" && <Chat />}
+          {ativo === "configuracoes" && <Configuracoes />}
+        </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace `react-icons` and the MUI line chart with emoji-based icons and a custom SVG chart component
- wire the dashboard and consultas screens to the new chart/icons and clean up sidebar branding and favicon path
- lock TypeScript to 5.8.2 in the toolchain so npm install no longer fails on peer dependency constraints

## Testing
- npm run build *(fails: missing type definitions because registry access is blocked in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4dd7d5548330a2efb3f4b009d090)