### PR TITLE
Ensure X-Client header is sent with API requests

### DIFF
--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -14,6 +14,8 @@ async function testLoginSuccess() {
       assert.equal(url, "https://api.nextmind.sbs/sanctum/csrf-cookie");
       assert.equal(init?.method ?? "GET", "GET");
       assert.equal(init?.credentials, "include");
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("X-Client"), "web");
       return new Response(null, { status: 204 });
     }
 
@@ -21,6 +23,8 @@ async function testLoginSuccess() {
     assert.equal(url, "https://api.nextmind.sbs/login");
     assert.equal(init?.method, "POST");
     assert.equal(init?.credentials, "include");
+    const headers = new Headers(init?.headers);
+    assert.equal(headers.get("X-Client"), "web");
     const body = init?.body ? JSON.parse(String(init.body)) : null;
     assert.deepEqual(body, { email: "user@example.com", password: "secret" });
 
@@ -46,8 +50,13 @@ async function testLoginUnauthorized() {
     requests.push({ url, options: init });
 
     if (requests.length === 1) {
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("X-Client"), "web");
       return new Response(null, { status: 204 });
     }
+
+    const headers = new Headers(init?.headers);
+    assert.equal(headers.get("X-Client"), "web");
 
     return new Response(JSON.stringify({ message: "Credenciais inválidas" }), {
       status: 401,

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -79,6 +79,10 @@ export async function httpRequest<T>(path: string, options: RequestOptions = {})
     finalHeaders.set("Accept", "application/json");
   }
 
+  if (!finalHeaders.has("X-Client")) {
+    finalHeaders.set("X-Client", "web");
+  }
+
   if (token && !finalHeaders.has("Authorization")) {
     finalHeaders.set("Authorization", `Bearer ${token}`);
   }


### PR DESCRIPTION
## Summary
- add a default X-Client: web header to every HTTP request
- extend login tests to verify the header is sent during authentication flows

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f53b31990833091b706012e746ecb)