### PR TITLE
Centralize routing configuration and guards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,93 @@
-import Login from "./pages/Login/Login";
-import Dashboard from "./pages/Dasboard/Dashboard";
+import {
+  type ComponentType,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { clearAuthState, useAuthState } from "./stores/authStore";
+import { getInitialRoutePath, resolveRoute } from "./routes/router";
+import type { DashboardProps } from "./pages/Dasboard/Dashboard";
+
+function getInitialPathname() {
+  if (typeof window === "undefined") {
+    return getInitialRoutePath("/");
+  }
+
+  return getInitialRoutePath(window.location.pathname);
+}
 
 export default function App() {
   const { token } = useAuthState();
   const usuarioLogado = Boolean(token);
+  const [currentPath, setCurrentPath] = useState(getInitialPathname);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handlePopState = () => {
+      setCurrentPath(getInitialRoutePath(window.location.pathname));
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, []);
+
+  const navigate = useCallback(
+    (to: string, { replace = false }: { replace?: boolean } = {}) => {
+      const normalizedPath = getInitialRoutePath(to);
+      setCurrentPath((previousPath) =>
+        previousPath === normalizedPath ? previousPath : normalizedPath
+      );
+
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      if (replace) {
+        window.history.replaceState({}, "", normalizedPath);
+      } else if (window.location.pathname !== normalizedPath) {
+        window.history.pushState({}, "", normalizedPath);
+      }
+    },
+    []
+  );
+
+  const { route, redirectPath } = useMemo(
+    () =>
+      resolveRoute(currentPath, {
+        isAuthenticated: usuarioLogado,
+      }),
+    [currentPath, usuarioLogado]
+  );
+
+  useEffect(() => {
+    if (redirectPath && redirectPath !== currentPath) {
+      navigate(redirectPath, { replace: true });
+      return;
+    }
+
+    if (typeof window !== "undefined" && window.location.pathname !== currentPath) {
+      navigate(currentPath, { replace: true });
+    }
+  }, [redirectPath, currentPath, navigate]);
 
   const handleLogout = () => {
     clearAuthState();
+    navigate("/login", { replace: true });
   };
 
-  return usuarioLogado ? <Dashboard onLogout={handleLogout} /> : <Login />;
+  const RouteComponent = route.component;
+
+  if (route.path === "/dashboard") {
+    const DashboardComponent = RouteComponent as ComponentType<DashboardProps>;
+    return <DashboardComponent onLogout={handleLogout} />;
+  }
+
+  const GenericComponent = RouteComponent as ComponentType<Record<string, never>>;
+  return <GenericComponent />;
 }

--- a/src/pages/Dasboard/Dashboard.tsx
+++ b/src/pages/Dasboard/Dashboard.tsx
@@ -8,7 +8,7 @@ import Chat from "../Chat/Chat";
 import Configuracoes from "../Configuracoes/Configuracoes";
 
 
-interface DashboardProps {
+export interface DashboardProps {
   onLogout?: () => void;
 }
 

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,0 +1,84 @@
+import type { ComponentType } from "react";
+import Dashboard from "../pages/Dasboard/Dashboard";
+import Login from "../pages/Login/Login";
+
+export type NavigationContext = {
+  isAuthenticated: boolean;
+};
+
+export type Guard = (context: NavigationContext) => string | null;
+
+export interface RouteDefinition {
+  path: string;
+  component: ComponentType<unknown>;
+  guard?: Guard;
+}
+
+export const mustBeAuthenticated: Guard = ({ isAuthenticated }) =>
+  isAuthenticated ? null : "/login";
+
+export const mustBeGuest: Guard = ({ isAuthenticated }) =>
+  isAuthenticated ? "/dashboard" : null;
+
+export const routes: RouteDefinition[] = [
+  { path: "/login", component: Login, guard: mustBeGuest },
+  { path: "/dashboard", component: Dashboard, guard: mustBeAuthenticated },
+];
+
+const defaultRoute = routes[0];
+
+function resolveGuardRedirect(
+  route: RouteDefinition,
+  context: NavigationContext,
+  currentPath: string
+): { route: RouteDefinition; redirectPath: string } | null {
+  if (!route.guard) {
+    return null;
+  }
+
+  const redirectPath = route.guard(context);
+  if (!redirectPath || redirectPath === currentPath) {
+    return null;
+  }
+
+  const redirectRoute =
+    routes.find((candidate) => candidate.path === redirectPath) ?? defaultRoute;
+
+  return {
+    route: redirectRoute,
+    redirectPath,
+  };
+}
+
+export function resolveRoute(
+  path: string,
+  context: NavigationContext
+): { route: RouteDefinition; redirectPath: string | null } {
+  const matchedRoute = routes.find((candidate) => candidate.path === path);
+  const baseRoute = matchedRoute ?? defaultRoute;
+
+  const guardResult = resolveGuardRedirect(baseRoute, context, path);
+  if (guardResult) {
+    return guardResult;
+  }
+
+  if (!matchedRoute) {
+    return {
+      route: baseRoute,
+      redirectPath: baseRoute.path,
+    };
+  }
+
+  return {
+    route: baseRoute,
+    redirectPath: null,
+  };
+}
+
+export function getInitialRoutePath(pathname: string | undefined) {
+  if (!pathname || pathname === "/") {
+    return defaultRoute.path;
+  }
+
+  return pathname;
+}

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -70,13 +70,17 @@ export async function httpRequest<T>(path: string, options: RequestOptions = {})
   const finalHeaders = new Headers(headers ?? {});
 
   function getCookie(name: string) {
-    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    if (typeof document === "undefined") {
+      return null;
+    }
+
+    const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
     return match ? decodeURIComponent(match[2]) : null;
   }
 
-  const xsrf = getCookie('XSRF-TOKEN');
-  if (xsrf && !finalHeaders.has('X-XSRF-TOKEN')) {
-    finalHeaders.set('X-XSRF-TOKEN', xsrf);
+  const xsrf = getCookie("XSRF-TOKEN");
+  if (xsrf && !finalHeaders.has("X-XSRF-TOKEN")) {
+    finalHeaders.set("X-XSRF-TOKEN", xsrf);
   }
 
   if (parseJson && body !== undefined && !(body instanceof FormData)) {
@@ -90,7 +94,7 @@ export async function httpRequest<T>(path: string, options: RequestOptions = {})
   }
 
   if (!finalHeaders.has("X-Requested-With")) {
-  finalHeaders.set("X-Requested-With", "XMLHttpRequest");
+    finalHeaders.set("X-Requested-With", "XMLHttpRequest");
   }
 
   if (!finalHeaders.has("X-Client")) {


### PR DESCRIPTION
## Summary
- centralize login and dashboard route definitions with guard helpers in a dedicated router module
- update the App component to resolve routes via guard-aware navigation and keep browser history in sync
- expose dashboard props typing for reuse in route rendering logic

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fafa123b48330b815d011aebc8b50)