### PR TITLE
Handle cookie-based auth sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { clearAuthState, useAuthState } from "./stores/authStore";
+import { clearAuthState, isAuthenticated, useAuthState } from "./stores/authStore";
 import { getInitialRoutePath, resolveRoute } from "./routes/router";
 import type { DashboardProps } from "./pages/Dasboard/Dashboard";
 
@@ -18,8 +18,8 @@ function getInitialPathname() {
 }
 
 export default function App() {
-  const { token } = useAuthState();
-  const usuarioLogado = Boolean(token);
+  const authState = useAuthState();
+  const usuarioLogado = isAuthenticated(authState);
   const [currentPath, setCurrentPath] = useState(getInitialPathname);
 
   useEffect(() => {

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { login } from "../services/auth";
-import { clearAuthState, getAuthState } from "../stores/authStoreBase";
+import {
+  clearAuthState,
+  getAuthState,
+  isAuthenticated,
+  setAuthState,
+} from "../stores/authStoreBase";
 
 async function testLoginSuccess() {
   clearAuthState();
@@ -75,10 +80,26 @@ async function testLoginUnauthorized() {
   assert.equal(getAuthState().token, null);
 }
 
+async function testAuthenticationStateHeuristics() {
+  clearAuthState();
+  assert.equal(isAuthenticated(getAuthState()), false);
+
+  setAuthState({ token: "abc" });
+  assert.equal(isAuthenticated(getAuthState()), true);
+
+  clearAuthState();
+  setAuthState({ data: { id: 1 }, token: null });
+  assert.equal(isAuthenticated(getAuthState()), true);
+}
+
 export async function runTests() {
   const tests: Array<[string, () => Promise<void>]> = [
     ["should perform login and return response", testLoginSuccess],
     ["should throw for unauthorized login", testLoginUnauthorized],
+    [
+      "should detect authentication when token is missing but user data exists",
+      testAuthenticationStateHeuristics,
+    ],
   ];
 
   let failures = 0;

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,7 +2,13 @@ import { useSyncExternalStore } from "react";
 import { getAuthState, getInitialAuthState, subscribeAuthState } from "./authStoreBase";
 import type { AuthState } from "./authStoreBase";
 
-export { clearAuthState, getAuthState, getInitialAuthState, setAuthState } from "./authStoreBase";
+export {
+  clearAuthState,
+  getAuthState,
+  getInitialAuthState,
+  isAuthenticated,
+  setAuthState,
+} from "./authStoreBase";
 export type { AuthState } from "./authStoreBase";
 
 export function useAuthState(): AuthState {

--- a/src/stores/authStoreBase.ts
+++ b/src/stores/authStoreBase.ts
@@ -78,3 +78,15 @@ export function subscribeAuthState(listener: (next: AuthState) => void) {
 export function getInitialAuthState() {
   return initialState;
 }
+
+function hasValidToken(token: string | null): boolean {
+  return typeof token === "string" && token.trim().length > 0;
+}
+
+export function isAuthenticated(nextState: AuthState): boolean {
+  if (hasValidToken(nextState.token)) {
+    return true;
+  }
+
+  return nextState.data !== null && nextState.data !== undefined;
+}


### PR DESCRIPTION
## Summary
- ensure the application treats a successful login as authenticated even when the API does not return a bearer token
- expose an `isAuthenticated` helper in the auth store and consume it from the App routing logic
- cover the new authentication heuristic with a unit test

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb98f2bd88330ba5f1d206696479b)